### PR TITLE
feat: Add redirect and error messaging

### DIFF
--- a/src/main/java/com/udacity/jwdnd/course1/cloudstorage/controllers/SignupController.java
+++ b/src/main/java/com/udacity/jwdnd/course1/cloudstorage/controllers/SignupController.java
@@ -41,7 +41,7 @@ public class SignupController {
         }
 
         if (signupError == null) {
-            model.addAttribute("signupSuccess", true);
+            return "redirect:/login?success";
         } else {
             model.addAttribute("signupError", signupError);
         }

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -15,8 +15,11 @@
                 <div class="alert alert-danger" th:if="${param.error}">
                     Invalid username or password
                 </div>
-                <div class="alert alert-dark" th:if="${param.logout}">
+                <div class="alert alert-success" th:if="${param.logout}">
                     You have been logged out
+                </div>
+                <div class="alert alert-success" th:if="${param.success}">
+                    You successfully signed up!
                 </div>
                 <div class="form-group">
                     <label for="inputUsername">Username</label>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -16,11 +16,8 @@
 
             <h1 class="display-5">Sign Up</h1>
             <form action="#" th:action="@{/signup}" method="POST" th:object="${signup}">
-                <div class="alert alert-dark" th:if="${signupSuccess}">
-                    You successfully signed up! Please continue to the <a>login</a> page.
-                </div>
                 <div class="alert alert-danger" th:if="${signupError}">
-                    <span>Example Signup Error Message</span>
+                    <span th:text="${signupError}"></span>
                 </div>
                 <div class="form-row">
                     <div class="form-group col-md-6">


### PR DESCRIPTION
When a user signs up successfully, redirect
them to the login page with a success
message. When a user attempts to sign up with
a username that is already taken, show them
a message on the signup page.

Resolves #8